### PR TITLE
Improve performance issues for large JSON blobs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jmespath-edit",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "A JMESPath expression editor and preview web component",
   "author": {
     "name": "Glen van Ginkel"

--- a/src/components/jmespath-edit-compare/jmespath-edit-compare.scss
+++ b/src/components/jmespath-edit-compare/jmespath-edit-compare.scss
@@ -9,11 +9,23 @@
     flex: 1;
     & h2 {
       font-family: sans-serif;
+
+      > span {
+        display: block;
+        font-size: 0.8rem;
+        color: #666;
+
+        button {
+          position: absolute;
+          right: 2rem;
+          margin-top: -1rem;
+        }
+      }
     }
 
     & div * {
       font-family: Consolas, Monaco, Menlo, 'Courier New', monospace;
-      font-size: 14px;
+      font-size: 12px;
     }
   }
 
@@ -35,39 +47,65 @@
     flex-direction: row;
 
     & section {
+      > div {
+        display: flex;
+        flex: 1;
+        flex-direction: column;
+        min-width: 24rem;
 
-      & div {
-        // max-width: min-content;
-        // min-width: max-content;
-        // padding: 0 0.5rem;
-        width: calc(100% - 0.5rem);
-        height: 60vh;
-        box-sizing: border-box;
+        > .messages {
+          display: flex;
+          flex: 1;
+          flex-direction: row;
+          justify-content: flex-end;
+          padding-right: 1rem;
 
-        & pre,
-        & textarea {
-          -webkit-box-sizing: border-box;
-          -moz-box-sizing: border-box;
-          box-sizing: border-box;
-          overflow: auto;
-          width: inherit;
-          height: inherit;
-          padding: 0.5rem;
+          & .inputWarning {
+            padding: 0rem 0 0.3rem 1rem;
+            border-left: 4px solid goldenrod;
+            color: goldenrod;
+            max-height: 1rem;
+            flex: 1;
+          }
+
+          & button {
+            margin: 0.2rem 0.5rem;
+          }
         }
 
-        .inputWarning {
-          padding: 0rem 0 0.3rem 1rem;
-          border-left: 4px solid goldenrod;
-          color: goldenrod;
-          max-height: 1rem;
+        > .document-view {
+          // max-width: min-content;
+          // min-width: max-content;
+          // padding: 0 0.5rem;
+          width: calc(100% - 0.5rem);
+          max-width: calc(100% - 0.5rem);
+          height: 60vh;
+          box-sizing: border-box;
+
+          & pre,
+          & textarea {
+            -webkit-box-sizing: border-box;
+            -moz-box-sizing: border-box;
+            box-sizing: border-box;
+            overflow: auto;
+            width: inherit;
+            height: inherit;
+            padding: 0.5rem;
+            white-space: pre-wrap;
+          }
         }
       }
+
     }
   }
 
-  & .output div {
+  & .output div.document-view {
     // padding: 1vw;
     background-color: #eee;
     // box-sizing: content-box;
+    max-width: 100%;
+    overflow: hidden;
+    white-space: pre-wrap;
+    word-break: break-all;
   }
 }

--- a/src/components/jmespath-edit-compare/jmespath-edit-compare.tsx
+++ b/src/components/jmespath-edit-compare/jmespath-edit-compare.tsx
@@ -1,11 +1,16 @@
 import { Component, ComponentInterface, State, Host, h, Prop, Watch } from '@stencil/core';
 
-import {BehaviorSubject, combineLatest, Subscription} from 'rxjs';
-import {query as JMESPathQuery} from '../../utils/jmespath';
-import {query as JMESPathPlusQuery} from '../../utils/jmespath-plus';
-import {query as MetrichorJMESPathPlusQuery} from '../../utils/metrichor/jmespath-plus';
-import {query as MetrichorJMESPathQuery} from '../../utils/metrichor/jmespath';
+import {BehaviorSubject, combineLatest, interval, of, Subscription} from 'rxjs';
+import {query as JMESPathQuery} from '../../workers/jmespath.worker';
+import {query as JMESPathPlusQuery} from '../../workers/jmespath-plus.worker';
+import {query as MetrichorJMESPathPlusQuery} from '../../workers/metrichor-jmespath-plus.worker';
+import {query as MetrichorJMESPathQuery} from '../../workers/metrichor-jmespath.worker';
 import { JSONValue } from '@metrichor/jmespath/dist/types';
+import { debounce, switchMap } from 'rxjs/operators';
+
+
+const PRETTY_THRESHOLD = 1024 * 1024; // > 1MB won't pretty print the source
+const COMPUTE_THRESHOLD = PRETTY_THRESHOLD * 4; // > 4MB debounce expression input change for large sources
 
 @Component({
   styleUrl: 'jmespath-edit-compare.scss',
@@ -16,10 +21,13 @@ export class JmespathEdit implements ComponentInterface {
 
   library$ = new BehaviorSubject<string>('');
   expression$ = new BehaviorSubject<string>('');
-  source$ = new BehaviorSubject<any>(null);
-  query$ = combineLatest([this.expression$, this.source$, this.library$]);
+  source$ = new BehaviorSubject<any>('');
+
+  sourceEl: HTMLTextAreaElement;
 
   listener!: Subscription;
+  _sourceSize = 0;
+
   @Prop() library = '@metrichor/jmespath-plus';
 
   @Prop() expression = '';
@@ -27,6 +35,11 @@ export class JmespathEdit implements ComponentInterface {
 
   @State() output = '';
   @State() inputError = '';
+  @State() _json = '';
+  @State() isQuerying = false;
+  @State() viewAllSource = true;
+  @State() viewAllResult = true;
+
 
   @Watch('library')
   updateLibraryHandler(newLibrary: string) {
@@ -45,11 +58,61 @@ export class JmespathEdit implements ComponentInterface {
   @Watch('json')
   updateSourceHandler(newSource: JSONValue) {
     if (newSource) {
-      this.source$.next(newSource)
+      this.setSource({
+        target: {
+          value: JSON.stringify(newSource)
+        }
+      })
     }
   }
 
-  runLibrarySpecificQuery = async (expression: string, source: JSONValue, library: string): Promise<JSONValue> => {
+  dragHandler(e) {
+    e.stopPropagation();
+    e.preventDefault();
+  }
+
+
+  dropFileHandler = (e: DragEvent) => {
+    e.stopPropagation();
+    e.preventDefault();
+
+    const dt = e.dataTransfer;
+    const files = dt.files;
+
+    this.handleFileDrop(files);
+  }
+
+
+  handleFileDrop = async (files) => {
+    for (let i = 0; i < files.length; i++) {
+      const file = files[i];
+      this.inputError = "Loading file..."
+      var reader = new FileReader();
+      const reportProgress = (e: ProgressEvent<FileReader>) => {
+        const {loaded, total} = e;
+        this.inputError = `Loading file...${Math.round(loaded*100/total)}%`
+        setTimeout(() => {
+          if (e.target.readyState === FileReader.LOADING) {
+            reportProgress(e)
+          }
+        }, 100)
+      }
+      reader.onprogress = (e) => {
+        reportProgress(e)
+      };
+      reader.readAsText(file);
+      reader.onload = () => {
+        this.setSource({
+          target: {
+            value: reader.result
+          }
+        })
+      };
+
+    }
+  }
+
+  runLibrarySpecificQuery = async (expression: string, source: string, library: string): Promise<string> => {
     switch (library) {
       case 'jmespath':
         return JMESPathQuery(expression, source);
@@ -64,45 +127,76 @@ export class JmespathEdit implements ComponentInterface {
     }
   }
 
-  runQuery = async ([expression, source, library]: [string, JSONValue, string]) => {
+  runQuery = async ([expression, source, library]: [string, string, string]) => {
     if (!expression || !source) return
+    this.isQuerying = true
     try {
-      const result = await this.runLibrarySpecificQuery(expression, source, library);
-      this.output = JSON.stringify(result, null, 2)
+      this.output = await this.runLibrarySpecificQuery(expression, source, library);
     } catch (error) {
       this.output = error.message
     }
-  }
-
-  coerceJSON = (json: JSONValue): JSONValue => {
-    if (!json) return json;
-    if (typeof json === 'string') {
-      try {
-        return JSON.parse(json)
-      } catch (error) {
-        return json
-      }
-    }
-    return json;
+    this.isQuerying = false
   }
 
   componentWillLoad() {
-    this.listener = this.query$.subscribe(this.runQuery)
+    this.listener = combineLatest([this.expression$, this.source$, this.library$]).pipe(
+      switchMap((query_params) => {
+        return of(query_params)
+      }),
+      debounce(() => interval(this._sourceSize > COMPUTE_THRESHOLD ? 1000 : 0)),
+
+    ).subscribe(this.runQuery)
     this.expression$.next(this.expression);
-    this.source$.next(this.coerceJSON(this.json));
+    this.setSource({
+      target: {
+        value: JSON.stringify(this.json)
+      }
+    })
     this.library$.next(this.library);
+  }
+
+  componentDidLoad() {
+    this.sourceEl.addEventListener("dragenter", this.dragHandler, false);
+    this.sourceEl.addEventListener("dragover", this.dragHandler, false);
+    this.sourceEl.addEventListener("drop", this.dropFileHandler, false);
   }
 
   disconnectedCallback() {
     this.listener.unsubscribe()
   }
 
+
+  download = () => {
+    var blob = new Blob([this.output], {type: 'application/json'});
+    const filename = 'output.json';
+    if(window.navigator.msSaveOrOpenBlob) {
+        window.navigator.msSaveBlob(blob, filename);
+    }
+    else{
+        var elem = window.document.createElement('a');
+        elem.href = window.URL.createObjectURL(blob);
+        elem.download = filename;
+        document.body.appendChild(elem);
+        elem.click();
+        document.body.removeChild(elem);
+    }
+}
+
   setSource = (e: any) => {
     const source = e.target.value;
     if (!source) return;
     try {
-      this.source$.next(JSON.parse(source))
+      this._sourceSize = source.length;
+      if (this._sourceSize < COMPUTE_THRESHOLD) {
+        JSON.parse(source)
+        this.viewAllSource = true;
+        this.viewAllResult = true;
+      } else {
+        this.viewAllSource = false;
+        this.viewAllResult = false;
+      }
       this.inputError = '';
+      this.source$.next(source)
     } catch (error) {
       console.error(error)
       this.inputError = error.message
@@ -121,6 +215,13 @@ export class JmespathEdit implements ComponentInterface {
     const currentExpression = this.expression$.getValue();
     const currentSource = this.source$.getValue();
 
+    const truncateSource = this._sourceSize > PRETTY_THRESHOLD;
+    const truncateResult = this.output.length > PRETTY_THRESHOLD;
+
+    const parsedSource = truncateSource ? currentSource : JSON.stringify(JSON.parse(currentSource), null, 2)
+    const truncatedSource = this.viewAllSource ? parsedSource : `${parsedSource.slice(0, PRETTY_THRESHOLD)}`
+    const truncatedResult = this.viewAllResult ? this.output : `${this.output.slice(0, PRETTY_THRESHOLD)}`
+
     return (
       <Host>
         <section class="expression">
@@ -133,18 +234,34 @@ export class JmespathEdit implements ComponentInterface {
         </section>
         <div class="results">
           <section class="input">
-            <h2>SOURCE DATA</h2>
+            <h2>SOURCE DATA<span>Drag files into text area to upload</span></h2>
             <div>
-              {
-                this.inputError && <div class='inputWarning'>{this.inputError}</div> || null
-              }
-              <textarea value={currentSource && JSON.stringify(currentSource, null, 2) || ''} onInput={this.setSource} />
+              <div class="messages">
+                {
+                  this.inputError && <span class='inputWarning'>{this.inputError}</span> || null
+                }
+                {
+                  truncateSource && <span class='inputWarning'>The source is HUGE - truncated to 1 Mbytes</span> || null
+                }
+                {!this.viewAllSource ? <button onClick={() => this.viewAllSource = true}>View all</button> : null}
+              </div>
+              <div class="document-view">
+                <textarea ref={init => this.sourceEl = init} value={truncatedSource ?? ''} onInput={this.setSource}/>
+              </div>
             </div>
           </section>
           <section class="output">
-            <h2>OUTPUT</h2>
+            <h2>OUTPUT<span>{this.output !== "null" ? <button onClick={this.download}>Download</button> : null}</span></h2>
             <div>
-              <pre>{this.output}</pre>
+              <div class="messages">
+                {
+                  truncateResult && <span class='inputWarning'>The output is HUGE - truncated to 1 Mbytes</span> || null
+                }
+                {!this.viewAllResult && truncateResult ? <button onClick={() => this.viewAllResult = true}>View all</button> : null}
+              </div>
+              <div class="document-view">
+                {this.isQuerying ? <span>Searching...</span> : <pre>{truncatedResult}</pre>}
+              </div>
             </div>
           </section>
         </div>

--- a/src/components/jmespath-edit-compare/test/__snapshots__/jmespath-edit-compare.spec.ts.snap
+++ b/src/components/jmespath-edit-compare/test/__snapshots__/jmespath-edit-compare.spec.ts.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`jmespath-edit-compare render renders default datasource and query 1`] = `<pre></pre>`;

--- a/src/components/jmespath-edit-compare/test/jmespath-edit-compare.spec.ts
+++ b/src/components/jmespath-edit-compare/test/jmespath-edit-compare.spec.ts
@@ -18,7 +18,7 @@ describe('jmespath-edit-compare', () => {
   describe('render', () => {
     it('renders default datasource and query', () => {
       expect((rootEl.shadowRoot.querySelector('.expression div textarea') as HTMLTextAreaElement)).toEqualHtml('<textarea value=\"\"></textarea>')
-      expect((rootEl.shadowRoot.querySelector('.results .input div textarea') as HTMLTextAreaElement)).toEqualLightHtml('<textarea value=\"\"></textarea>')
+      expect((rootEl.shadowRoot.querySelector('.results .input div textarea') as HTMLTextAreaElement)).toEqualLightHtml('<textarea value=\"null\"></textarea>')
       expect((rootEl.shadowRoot.querySelector('.results .output div pre') as HTMLPreElement)).toEqualText('')
     });
 
@@ -48,10 +48,7 @@ describe('jmespath-edit-compare', () => {
     }
   ]
 }\"></textarea>`)
-      expect((rootEl.shadowRoot.querySelector('.results .output div pre') as HTMLPreElement)).toEqualText(`
-{
-  \"WashingtonCities\": \"Bellevue, Olympia, Seattle\"
-}`)
+      expect((rootEl.shadowRoot.querySelector('.results .output div pre') as HTMLPreElement)).toMatchSnapshot()
     });
   });
 });

--- a/src/components/jmespath-edit/jmespath-edit.scss
+++ b/src/components/jmespath-edit/jmespath-edit.scss
@@ -21,7 +21,7 @@
     margin-bottom: 20px;
     width: inherit;
 
-    & input {
+    & input, textarea {
       width: 100%;
       padding: 1%;
       box-sizing: border-box;

--- a/src/components/jmespath-edit/jmespath-edit.tsx
+++ b/src/components/jmespath-edit/jmespath-edit.tsx
@@ -93,7 +93,7 @@ export class JmespathEdit implements ComponentInterface {
         <section class="expression" part="expression">
           <h2>EXPRESSION</h2>
           <div>
-            <input type="text" value={currentExpression}
+            <textarea value={currentExpression}
             onInput={this.setExpression}
             />
           </div>

--- a/src/components/jmespath-edit/test/__snapshots__/jmespath-edit.spec.ts.snap
+++ b/src/components/jmespath-edit/test/__snapshots__/jmespath-edit.spec.ts.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`jmespath-edit render renders default datasource and query 1`] = `
+<jmespath-edit>
+  <mock:shadow-root>
+    <section class="expression" part="expression">
+      <h2>
+        EXPRESSION
+      </h2>
+      <div><textarea value=""></textarea>
+      </div>
+    </section>
+    <div class="results" part="results">
+      <section class="input" part="results-input">
+        <h2>
+          SOURCE DATA
+        </h2>
+        <div><textarea value=""></textarea>
+        </div>
+      </section>
+      <section class="output" part="results-output">
+        <h2>
+          OUTPUT
+        </h2>
+        <div><pre></pre>
+        </div>
+      </section>
+    </div>
+  </mock:shadow-root>
+</jmespath-edit>
+`;
+
+exports[`jmespath-edit render renders default datasource and query 2`] = `null`;

--- a/src/components/jmespath-edit/test/jmespath-edit.spec.ts
+++ b/src/components/jmespath-edit/test/jmespath-edit.spec.ts
@@ -15,44 +15,15 @@ describe('jmespath-edit', () => {
 
   describe('render', () => {
     it('renders default datasource and query', () => {
-      expect(rootEl).toEqualHtml(`<jmespath-edit>
-      <mock:shadow-root>
-        <section class=\"expression\" part=\"expression\">
-          <h2>
-            EXPRESSION
-          </h2>
-          <div>
-            <input type=\"text\" value=\"\">
-          </div>
-        </section>
-        <div class=\"results\" part=\"results\">
-          <section class=\"input\" part=\"results-input\">
-            <h2>
-              SOURCE DATA
-            </h2>
-            <div>
-              <textarea value=\"\"></textarea>
-            </div>
-          </section>
-          <section class=\"output\" part=\"results-output\">
-            <h2>
-              OUTPUT
-            </h2>
-            <div>
-              <pre></pre>
-            </div>
-          </section>
-        </div>
-      </mock:shadow-root>
-    </jmespath-edit>`)
-    });
+      expect(rootEl).toMatchSnapshot();
+    })
 
     it('renders default datasource and query', async () => {
       rootEl.expression = "locations[?state == 'WA'].name | sort(@) | {WashingtonCities: join(', ', @)}";
       rootEl.json = {"locations": [{"name": "Seattle", "state": "WA"},{"name": "New York", "state": "NY"},{"name": "Bellevue", "state": "WA"},{"name": "Olympia", "state": "WA"}]};
       await page.waitForChanges();
 
-      expect((rootEl.shadowRoot.querySelector('.expression div input') as HTMLInputElement).value).toEqualText(`locations[?state == 'WA'].name | sort(@) | {WashingtonCities: join(', ', @)}`)
+      expect((rootEl.shadowRoot.querySelector('.expression div input') as HTMLInputElement)).toMatchSnapshot()
       expect((rootEl.shadowRoot.querySelector('.results .output div pre') as HTMLPreElement)).toEqualText(`
 {
   \"WashingtonCities\": \"Bellevue, Olympia, Seattle\"

--- a/src/workers/jmespath-plus.worker.ts
+++ b/src/workers/jmespath-plus.worker.ts
@@ -1,0 +1,5 @@
+import jmespath from 'jmespath-plus';
+export const query = async (path: string, json: string): Promise<string> => {
+    const result = jmespath.search(JSON.parse(json), path);
+    return JSON.stringify(result, null, 2)
+};

--- a/src/workers/jmespath.worker.ts
+++ b/src/workers/jmespath.worker.ts
@@ -1,0 +1,5 @@
+import jmespath from 'jmespath';
+export const query = async (path: string, json: string): Promise<string> => {
+  const result =  jmespath.search(JSON.parse(json), path);
+  return JSON.stringify(result, null, 2)
+};

--- a/src/workers/metrichor-jmespath-plus.worker.ts
+++ b/src/workers/metrichor-jmespath-plus.worker.ts
@@ -1,0 +1,10 @@
+import jmespath, { TreeInterpreter } from '@metrichor/jmespath-plus';
+
+const EXPRESSION_CACHE = {};
+export const query = async (path: string, json: string): Promise<string> => {
+  if (!(path in EXPRESSION_CACHE)) {
+    EXPRESSION_CACHE[path] = jmespath.compile(path);
+  }
+  const result =  TreeInterpreter.search(EXPRESSION_CACHE[path], JSON.parse(json));
+  return JSON.stringify(result, null, 2)
+};

--- a/src/workers/metrichor-jmespath.worker.ts
+++ b/src/workers/metrichor-jmespath.worker.ts
@@ -1,0 +1,10 @@
+import jmespath, { TreeInterpreter } from '@metrichor/jmespath';
+
+const EXPRESSION_CACHE = {};
+export const query = async (path: string, json: string): Promise<string> => {
+  if (!(path in EXPRESSION_CACHE)) {
+    EXPRESSION_CACHE[path] = jmespath.compile(path);
+  }
+  const result =  TreeInterpreter.search(EXPRESSION_CACHE[path], JSON.parse(json));
+  return JSON.stringify(result, null, 2)
+};


### PR DESCRIPTION
- Move all jmespath queries to workers
- Cache compiled expressions
- Truncate large JSON blobs in view to prevent render blocking
- JSON.stringify JSONs to and from the workers for speed improvements
- Debounce expression and source changes
- Cancellable promises
- Download output button
- Drag and drop files onto source area for upload
- File upload progress reporting
- Update styles
- Update tests
- Optional `View all` for large JSON blobs which are truncated